### PR TITLE
Make inline indicator as $ and block one as $$

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,12 @@ then run `gitbook install`.
 ## Usage
 
 ```
-Inline math: $$\int_{-\infty}^\infty g(x) dx$$
+Inline math: $\int_{-\infty}^\infty g(x) dx$
 
 
 Block math:
 
-$$
-\int_{-\infty}^\infty g(x) dx
-$$
+$$\int_{-\infty}^\infty g(x) dx$$
 
 Or using the templating syntax:
 

--- a/index.js
+++ b/index.js
@@ -18,12 +18,12 @@ module.exports = {
         math: {
             shortcuts: {
                 parsers: ["markdown", "asciidoc", "restructuredtext"],
-                start: "$$",
-                end: "$$"
+                start: "$",
+                end: "$"
             },
             process: function(blk) {
                 var tex = blk.body;
-                var isInline = !(tex[0] == "\n");
+                var isInline = !(tex[0] === "$" && tex[tex.length-1] === "$");
                 var output = katex.renderToString(tex, {
                     displayMode: !isInline
                 });


### PR DESCRIPTION
I wonder why GitBook uses double dollar sign as an inline indicator in TeX-style language. It will be considered as a block indicator in most of browser and editor(e.g. Chrome, Atom) rendering plugins for MathJax/KaTeX. So if a user writes a markdown in GitHub or other websites like that, it will be rendered very different as GitBook, especially such as my writing work in Atom like this:
<img width="1497" alt="screen shot 2016-06-03 at 2 12 56 am" src="https://cloud.githubusercontent.com/assets/11534233/15755736/bc3db5a0-2930-11e6-85ec-03e5990d5b0d.png">
It really makes a math worker crazy...
